### PR TITLE
fix: removing multiple elements from same array

### DIFF
--- a/src/test/unit.test.ts
+++ b/src/test/unit.test.ts
@@ -3,6 +3,41 @@ import { expect } from 'chai';
 import JSONPatchQuery, { Operation } from '../JSONPatchQuery';
 
 suite('application/json-patch+query', () => {
+  suite('Generic Examples', () => {
+    test('Removing items using a complex query', () => {
+      const document = {
+        swagger: '2.0',
+        tags: [
+          { name: 'catalog' },
+          { name: 'category' },
+          { name: 'productOffering' },
+          { name: 'productOfferingPrice' },
+          { name: 'productSpecification' },
+          { name: 'importJob' },
+          { name: 'exportJob' },
+          { name: 'notification listeners (client side)' },
+          { name: 'events subscription' },
+        ],
+      };
+      const patch: Operation[] = [
+        {
+          op: 'remove',
+          path: "$.tags[?(@.name!='catalog' && @.name!='productOffering' && @.name!='productSpecification')]",
+        },
+      ];
+      const expected = {
+        swagger: '2.0',
+        tags: [
+          { name: 'catalog' },
+          { name: 'productOffering' },
+          { name: 'productSpecification' },
+        ],
+      };
+      const result = JSONPatchQuery.apply(document, patch);
+      expect(result).to.eql(expected);
+    });
+  });
+
   suite('TM Forum Examples', () => {
     test('Adding an attribute to one of the components of an array', () => {
       const document = {


### PR DESCRIPTION
currently when removing elements from an array, it is possible for the incorrect elements to be removed due to the paths for the elements becoming invalid.

this is due to the elements being removed upfront, so the indexes of the array are no longer applicable since it has been modified.

this PR fixes the issue, by replacing the removed element with a unique Symbol and removing the elements after the entire collection of paths has been executed against.

resolves #3 