### PR TITLE
fix: using special characters in fields for json path

### DIFF
--- a/src/JSONPatchQuery.ts
+++ b/src/JSONPatchQuery.ts
@@ -319,7 +319,7 @@ export default class JSONPatchQuery {
         throw new Error(`Provided JSON Path did not resolve any nodes, path: ${operation.path}`);
       }
       const pathArray = operation.path.split('.');
-      const addition = { key: pathArray.pop()?.replace('`', ''), path: pathArray.join('.') };
+      const addition = { key: pathArray.pop()?.replace(/^`/, ''), path: pathArray.join('.') };
       const addResults: string[] = JSONPath({ path: addition.path, json: document, resultType: 'path' });
       const additionPaths = addResults.map((result) => JSONPath.toPathArray(result) as string[]);
       if (additionPaths.length > 0 && addition.key) {

--- a/src/JSONPatchQuery.ts
+++ b/src/JSONPatchQuery.ts
@@ -315,11 +315,11 @@ export default class JSONPatchQuery {
     // and add the property that doesn't exist
     if (paths.length === 0 && operation.op === 'add') {
       // check to see if the path does end in a static property (case where final node is a query)
-      if (!/^(.*)\.[a-z]*$/i.test(operation.path)) {
+      if (!/^(.*)\.[`\w@#\-$]*$/i.test(operation.path)) {
         throw new Error(`Provided JSON Path did not resolve any nodes, path: ${operation.path}`);
       }
       const pathArray = operation.path.split('.');
-      const addition = { key: pathArray.pop(), path: pathArray.join('.') };
+      const addition = { key: pathArray.pop()?.replace('`', ''), path: pathArray.join('.') };
       const addResults: string[] = JSONPath({ path: addition.path, json: document, resultType: 'path' });
       const additionPaths = addResults.map((result) => JSONPath.toPathArray(result) as string[]);
       if (additionPaths.length > 0 && addition.key) {

--- a/src/test/unit.test.ts
+++ b/src/test/unit.test.ts
@@ -50,6 +50,61 @@ suite('application/json-patch+query', () => {
       const result = JSONPatchQuery.apply(document, patch);
       expect(result).to.eql(expected);
     });
+
+    test('Performing an add operation with a field that contains a number', () => {
+      const document = { id: 342 };
+      const patch: Operation[] = [
+        {
+          op: 'add',
+          path: '$.name2',
+          value: 'Jane Doe',
+        },
+      ];
+      const expected = { id: 342, name2: 'Jane Doe' };
+      const result = JSONPatchQuery.apply(document, patch);
+      expect(result).to.eql(expected);
+    });
+
+    test('Performing an add operation with a field that contains a special character', () => {
+      const document = { id: 342 };
+      const patch: Operation[] = [
+        {
+          op: 'add',
+          path: '$.`@href',
+          value: '/jane-doe',
+        },
+      ];
+      const expected = { id: 342, '@href': '/jane-doe' };
+      const result = JSONPatchQuery.apply(document, patch);
+      expect(result).to.eql(expected);
+    });
+
+    test('Performing an add operation with a nested field that contains a special character', () => {
+      const document = { id: 342, details: { name: "Jane Doe" } };
+      const patch: Operation[] = [
+        {
+          op: 'add',
+          path: '$.details.`@href',
+          value: '/jane-doe',
+        },
+      ];
+      const expected = { id: 342, details: { '@href': '/jane-doe', name: "Jane Doe" } };
+      const result = JSONPatchQuery.apply(document, patch);
+      expect(result).to.eql(expected);
+    });
+
+    test('Performing a remove operation using the escape character', () => {
+      const document = { id: 342, details: { name: "Jane Doe", '@href': '/jane-doe' } };
+      const patch: Operation[] = [
+        {
+          op: 'remove',
+          path: '$.details.`@href',
+        },
+      ];
+      const expected = { id: 342, details: { name: "Jane Doe" } };
+      const result = JSONPatchQuery.apply(document, patch);
+      expect(result).to.eql(expected);
+    });
   });
 
   suite('test operation scenarios', () => {
@@ -327,6 +382,32 @@ suite('application/json-patch+query', () => {
           code: 123,
           state: 'ST',
         },
+      };
+      const result = JSONPatchQuery.apply(document, patch);
+      expect(result).to.eql(expected);
+    });
+
+    test('move an object value from one location to another with escape characters', () => {
+      const document = {
+        id: 342,
+        address: {
+          '@code': 123,
+          state: 'ST',
+        },
+      };
+      const patch: Operation[] = [
+        {
+          op: 'move',
+          path: '$.`@code',
+          from: '$.address.`@code',
+        },
+      ];
+      const expected = {
+        id: 342,
+        address: {
+          state: 'ST',
+        },
+        '@code': 123,
       };
       const result = JSONPatchQuery.apply(document, patch);
       expect(result).to.eql(expected);

--- a/src/test/unit.test.ts
+++ b/src/test/unit.test.ts
@@ -105,6 +105,20 @@ suite('application/json-patch+query', () => {
       const result = JSONPatchQuery.apply(document, patch);
       expect(result).to.eql(expected);
     });
+
+    test('Performing an add operation with a nested field that contains an escape character that is not used', () => {
+      const document = { id: 342, details: { name: "Jane Doe" } };
+      const patch: Operation[] = [
+        {
+          op: 'add',
+          path: '$.details.escape`string',
+          value: '/jane-doe',
+        },
+      ];
+      const expected = { id: 342, details: { 'escape`string': '/jane-doe', name: "Jane Doe" } };
+      const result = JSONPatchQuery.apply(document, patch);
+      expect(result).to.eql(expected);
+    });
   });
 
   suite('test operation scenarios', () => {


### PR DESCRIPTION
fix: fields being restricted to alphanumeric characters

- also support escape characters as per json path specification

fix: only escape characters at the beginning of the path
